### PR TITLE
adding support for SIGTERM

### DIFF
--- a/lib/natman.js
+++ b/lib/natman.js
@@ -78,6 +78,13 @@ Nat.prototype.map = function (options, callback) {
           process.exit(0);
         });
       });
+      
+      process.once('SIGTERM', function() {
+        client.portUnmapping(portInfo, function() {
+          // Ignore errors for now
+          process.exit(0);
+        });
+      });
 
       return callback(err, info);
     });


### PR DESCRIPTION
Supporting unmapping and exiting on SIGTERM allows for natman to be dockerized and easily used with "docker start" and "docker stop"
